### PR TITLE
[export] Add --convert option to convert between mesh types

### DIFF
--- a/include/mesh_sampling/assimp_scene.h
+++ b/include/mesh_sampling/assimp_scene.h
@@ -1,9 +1,15 @@
 #pragma once
 
-#include <assimp/Importer.hpp> // C++ importer interface
-#include <assimp/postprocess.h> // Post processing flags
-#include <assimp/scene.h> // Output data structure
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+
+#include <assimp/Exporter.hpp>
+#include <assimp/Importer.hpp>
+#include <assimp/postprocess.h>
+#include <assimp/scene.h>
+#include <sstream>
 #include <stdexcept>
+namespace bfs = boost::filesystem;
 
 namespace mesh_sampling
 {
@@ -35,6 +41,63 @@ public:
   const aiScene * scene() const
   {
     return scene_;
+  }
+
+  static std::vector<std::string> supportedExportFormats()
+  {
+    std::vector<std::string> supportedFormats;
+    Assimp::Exporter exporter;
+    auto numExporters = exporter.GetExportFormatCount();
+    for(auto i = 0u; i < numExporters; i++)
+    {
+      const aiExportFormatDesc * format = exporter.GetExportFormatDescription(i);
+      supportedFormats.push_back(format->fileExtension);
+    }
+    return supportedFormats;
+  }
+
+  /**
+   * @brief Export the scene to a file in a format supported by ASSIMP
+   * @see supportedExportFormats for a list of supported extensions
+   *
+   * @param path Export path
+   */
+  void exportScene(const std::string & path)
+  {
+    Assimp::Exporter exporter;
+    auto numExporters = exporter.GetExportFormatCount();
+    bfs::path out_path(path);
+    auto ext = boost::algorithm::to_lower_copy(out_path.extension().string());
+    if(ext.empty())
+    {
+      throw std::runtime_error("Could't export scene " + modelPath_ + " to " + path + ": invalid extension");
+    }
+    ext.erase(0, 1); // remove leading "."
+    // Find exporter id for this extension
+    int index = -1;
+    for(auto i = 0u; i < numExporters; i++)
+    {
+      const aiExportFormatDesc * format = exporter.GetExportFormatDescription(i);
+      if(ext == format->fileExtension)
+      {
+        index = i;
+        break;
+      }
+    }
+    if(index == -1)
+    { // Unsupported export format
+      std::string s;
+      const auto supportedFormats = supportedExportFormats();
+      std::ostringstream ss;
+      std::copy(supportedFormats.begin(), supportedFormats.end() - 1, std::ostream_iterator<std::string>(ss, ", "));
+      throw std::runtime_error("Could't export: unsupported format " + ext + "\nSupported formats are: " + ss.str());
+    }
+    const aiExportFormatDesc * format = exporter.GetExportFormatDescription(index);
+    aiReturn ret = exporter.Export(scene_, format->id, path);
+    if(ret != AI_SUCCESS)
+    {
+      throw std::runtime_error("ASSIMP failed to export scene " + modelPath_ + " to " + path);
+    }
   }
 
 protected:

--- a/include/mesh_sampling/assimp_scene.h
+++ b/include/mesh_sampling/assimp_scene.h
@@ -14,14 +14,8 @@ namespace bfs = boost::filesystem;
 namespace mesh_sampling
 {
 
-class ASSIMPScene
+struct ASSIMPScene
 {
-  // The importer will automatically delete the scene
-  Assimp::Importer importer;
-  const aiScene * scene_;
-  std::string modelPath_;
-
-public:
   ASSIMPScene(const std::string & model_path) : modelPath_(model_path)
   {
     loadScene();
@@ -43,29 +37,13 @@ public:
     return scene_;
   }
 
-  static std::vector<std::string> supportedExportFormats()
-  {
-    std::vector<std::string> supportedFormats;
-    Assimp::Exporter exporter;
-    auto numExporters = exporter.GetExportFormatCount();
-    for(auto i = 0u; i < numExporters; i++)
-    {
-      const aiExportFormatDesc * format = exporter.GetExportFormatDescription(i);
-      supportedFormats.push_back(format->fileExtension);
-    }
-    return supportedFormats;
-  }
-
   /**
    * @brief Export the scene to a file in a format supported by ASSIMP
-   * @see supportedExportFormats for a list of supported extensions
    *
    * @param path Export path
    */
-  void exportScene(const std::string & path)
+  void exportScene(const std::string & path, const bool binary = true)
   {
-    Assimp::Exporter exporter;
-    auto numExporters = exporter.GetExportFormatCount();
     bfs::path out_path(path);
     auto ext = boost::algorithm::to_lower_copy(out_path.extension().string());
     if(ext.empty())
@@ -73,30 +51,13 @@ public:
       throw std::runtime_error("Could't export scene " + modelPath_ + " to " + path + ": invalid extension");
     }
     ext.erase(0, 1); // remove leading "."
-    // Find exporter id for this extension
-    int index = -1;
-    for(auto i = 0u; i < numExporters; i++)
-    {
-      const aiExportFormatDesc * format = exporter.GetExportFormatDescription(i);
-      if(ext == format->fileExtension)
-      {
-        index = i;
-        break;
-      }
-    }
-    if(index == -1)
-    { // Unsupported export format
-      std::string s;
-      const auto supportedFormats = supportedExportFormats();
-      std::ostringstream ss;
-      std::copy(supportedFormats.begin(), supportedFormats.end() - 1, std::ostream_iterator<std::string>(ss, ", "));
-      throw std::runtime_error("Could't export: unsupported format " + ext + "\nSupported formats are: " + ss.str());
-    }
-    const aiExportFormatDesc * format = exporter.GetExportFormatDescription(index);
-    aiReturn ret = exporter.Export(scene_, format->id, path);
+    if(binary) ext += "b"; // ASSIMP suffixes binary export formats with "b"
+    Assimp::Exporter exporter;
+    aiReturn ret = exporter.Export(scene_, ext, path);
     if(ret != AI_SUCCESS)
     {
-      throw std::runtime_error("ASSIMP failed to export scene " + modelPath_ + " to " + path);
+      throw std::runtime_error("ASSIMP failed to export scene " + modelPath_ + " to " + path + ": "
+                               + exporter.GetErrorString());
     }
   }
 
@@ -113,6 +74,12 @@ protected:
       throw std::runtime_error(importer.GetErrorString());
     }
   }
+
+protected:
+  // The importer will automatically delete the scene
+  Assimp::Importer importer;
+  const aiScene * scene_;
+  std::string modelPath_;
 };
 
 } // namespace mesh_sampling

--- a/include/mesh_sampling/assimp_scene.h
+++ b/include/mesh_sampling/assimp_scene.h
@@ -7,7 +7,6 @@
 #include <assimp/Importer.hpp>
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
-#include <sstream>
 #include <stdexcept>
 namespace bfs = boost::filesystem;
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,8 @@ add_library(mesh_sampling SHARED
   ../include/mesh_sampling/weighted_random_sampling.h
   ../include/mesh_sampling/qhull_io.h
   )
-target_link_libraries(mesh_sampling PUBLIC mesh_sampling::assimp)
-target_link_libraries(mesh_sampling PUBLIC mesh_sampling::PCL)
+target_link_libraries(mesh_sampling PUBLIC mesh_sampling::assimp mesh_sampling::PCL)
+target_link_libraries(mesh_sampling PUBLIC Boost::filesystem)
 target_include_directories(mesh_sampling PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
 target_include_directories(mesh_sampling PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/ext>)
 
@@ -19,8 +19,7 @@ install(
   DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include)
 
 add_executable(mesh_sampling_bin mesh_sampling.cpp)
-target_link_libraries(mesh_sampling_bin PUBLIC mesh_sampling)
-target_link_libraries(mesh_sampling_bin PUBLIC Boost::program_options Boost::filesystem)
+target_link_libraries(mesh_sampling_bin PUBLIC mesh_sampling Boost::program_options)
 set_target_properties(mesh_sampling_bin PROPERTIES OUTPUT_NAME mesh_sampling)
 
 install(TARGETS mesh_sampling_bin

--- a/src/mesh_sampling.cpp
+++ b/src/mesh_sampling.cpp
@@ -111,7 +111,7 @@ int main(int argc, char ** argv)
     ("samples", po::value<unsigned>()->default_value(10000), "Number of points to sample")
     ("scale", po::value<float>()->default_value(1.0), "Scale factor applied to the mesh")
     ("type", po::value<std::string>()->default_value("xyz_rgb_normal"), "Type of cloud to generate (xyz, xyz_rgb, xyz_rgb_normal)")
-    ("binary", po::bool_switch()->default_value(false), "Outputs pointcloud in binary format (default: false)")
+    ("binary", po::bool_switch()->default_value(false), "Outputs in binary format (default: false)")
     ("convert", po::bool_switch()->default_value(false), "Convert from one mesh type to another (supported by ASSIMP)");
   // clang-format on
 
@@ -136,12 +136,12 @@ int main(int argc, char ** argv)
   std::string out_path = vm["out"].as<std::string>();
   bfs::path in_p(in_path);
   bfs::path out_p(out_path);
-  auto out_extension = boost::algorithm::to_lower_copy(out_p.extension().string());
-  unsigned N = vm["samples"].as<unsigned>();
-  std::string cloud_type = vm["type"].as<std::string>();
-  bool cloud_binary = vm["binary"].as<bool>();
-  auto supported_cloud_type = std::vector<std::string>{"xyz", "xyz_rgb", "xyz_normal", "xyz_rgb_normal"};
-  auto supported_extensions = std::vector<std::string>{".ply", ".pcd", ".qc", ".stl"};
+  const auto out_extension = boost::algorithm::to_lower_copy(out_p.extension().string());
+  const unsigned N = vm["samples"].as<unsigned>();
+  const std::string cloud_type = vm["type"].as<std::string>();
+  const bool binary_format = vm["binary"].as<bool>();
+  const auto supported_cloud_type = std::vector<std::string>{"xyz", "xyz_rgb", "xyz_normal", "xyz_rgb_normal"};
+  const auto supported_extensions = std::vector<std::string>{".ply", ".pcd", ".qc", ".stl"};
 
   auto check_supported = [](const std::vector<std::string> & supported, const std::string & value) {
     if(std::find(supported.begin(), supported.end(), value) == supported.end())
@@ -184,25 +184,25 @@ int main(int argc, char ** argv)
 
   if(convert)
   {
-    mesh->exportScene(out_path);
+    mesh->exportScene(out_path, binary_format);
   }
   else
   {
     if(cloud_type == "xyz")
     {
-      create_cloud<pcl::PointXYZ>(mesh->scene(), N, out_p, cloud_binary);
+      create_cloud<pcl::PointXYZ>(mesh->scene(), N, out_p, binary_format);
     }
     else if(cloud_type == "xyz_rgb")
     {
-      create_cloud<pcl::PointXYZRGB>(mesh->scene(), N, out_p, cloud_binary);
+      create_cloud<pcl::PointXYZRGB>(mesh->scene(), N, out_p, binary_format);
     }
     else if(cloud_type == "xyz_normal")
     {
-      create_cloud<pcl::PointNormal>(mesh->scene(), N, out_p, cloud_binary);
+      create_cloud<pcl::PointNormal>(mesh->scene(), N, out_p, binary_format);
     }
     else if(cloud_type == "xyz_rgb_normal")
     {
-      create_cloud<pcl::PointXYZRGBNormal>(mesh->scene(), N, out_p, cloud_binary);
+      create_cloud<pcl::PointXYZRGBNormal>(mesh->scene(), N, out_p, binary_format);
     }
   }
 


### PR DESCRIPTION
This PR adds an option to convert between mesh types using ASSIMP Exporter (without sampling):

```
mesh_sampling --convert --binary test.dae test.stl
```