### PR TITLE
Attempt to fix qhull convex generation

### DIFF
--- a/include/mesh_sampling/mesh_sampling.h
+++ b/include/mesh_sampling/mesh_sampling.h
@@ -82,6 +82,11 @@ public:
                                                      const fs::path & out_path = {},
                                                      bool stop_on_fail = true);
 
+  std::string run_qconvex_on_file(const fs::path & cloud_path, const fs::path & convex_path);
+  std::map<std::string, std::string> create_convexes_qconvex(const std::map<std::string, CloudT> & clouds,
+                                           const fs::path & out_path,
+                                           bool stop_on_fail = true);
+
   /**
    * @brief Export all meshes to a file in a format support by ASSIMP
    *

--- a/utils/mesh_sampling.cpp
+++ b/utils/mesh_sampling.cpp
@@ -23,6 +23,9 @@ int main(int argc, char ** argv)
   fs::path convex;
   app.add_option("--convex", convex, "Output convex directory")->check(CLI::ExistingPath);
 
+  bool use_qconvex = false;
+  app.add_flag("--use-qconvex", use_qconvex, "Use qconvex executable instead of libqhullcpp");
+
   unsigned int N;
   app.add_option("--samples", N, "Number of points to sample")->default_val(10000)->check(CLI::PositiveNumber);
 
@@ -57,25 +60,21 @@ int main(int argc, char ** argv)
   }
   else
   {
-    if(cloud_type == "xyz")
+    // Only these types are supported for convex generation
+    if(cloud_type == "xyz" || cloud_type == "xyz_rgb" || cloud_type == "xyz_normal" || cloud_type == "xyz_rgb_normal")
     {
       auto mesh = mesh_sampler.create_clouds(N, out, ".qc", binary_format);
-      if(!convex.empty()) mesh_sampler.create_convexes(mesh, convex);
+      if(!convex.empty())
+      {
+        if(use_qconvex)
+          mesh_sampler.create_convexes_qconvex(mesh, convex, true);
+        else
+          mesh_sampler.create_convexes(mesh, convex, true);
+      }
     }
-    else if(cloud_type == "xyz_rgb")
+    else
     {
-      auto mesh = mesh_sampler.create_clouds(N, out, ".qc", binary_format);
-      if(!convex.empty()) mesh_sampler.create_convexes(mesh, convex);
-    }
-    else if(cloud_type == "xyz_normal")
-    {
-      auto mesh = mesh_sampler.create_clouds(N, out, ".qc", binary_format);
-      if(!convex.empty()) mesh_sampler.create_convexes(mesh, convex);
-    }
-    else if(cloud_type == "xyz_rgb_normal")
-    {
-      auto mesh = mesh_sampler.create_clouds(N, out, ".qc", binary_format);
-      if(!convex.empty()) mesh_sampler.create_convexes(mesh, convex);
+      std::cerr << "Convex generation only supported for cloud types : xyz, xyz_rgb, xyz_normal, xyz_rgb_normal" << std::endl;
     }
   }
   return 0;


### PR DESCRIPTION
It seems that qhull sometimes struggles generating the convex hulls. This is at least the case with 

```
❯ qhull -V
qhull_r 8.0.2 (2020.2.r 2020/08/31)
```

However for the same files, the `qconvex` executable succeeds.
As a temporary workaround this PR adds a way to generate the convexes using the `qconvex` ( `--use-qconvex` flag) command instead of `qhull` library until a deeper fix can be found.

My guess is that there is a bug in qhull's re-entrant version used by the c++ wrapper, or our use of it, since that's the main difference between the standalone `qconvex` and the lib.

@ThomasDuvinage could you check with qhull version on your system if the file I provided you fails also?