### PR TITLE
Fix packaging

### DIFF
--- a/debian/libmesh-sampling-dev.install
+++ b/debian/libmesh-sampling-dev.install
@@ -1,3 +1,4 @@
 usr/include/*
 usr/lib/*/pkgconfig/*
+usr/lib/*/cmake/*
 usr/lib/cmake/*

--- a/debian/mesh-sampling.lintian-overrides
+++ b/debian/mesh-sampling.lintian-overrides
@@ -1,0 +1,1 @@
+mesh-sampling: lacks-ldconfig-trigger usr/lib/libmesh_sampling.so


### PR DESCRIPTION
Missing arch paths for cmake files `/usr/lib/x86_64*/cmake/*`
